### PR TITLE
[HQ-7449] Inline app-blacklist publish workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,15 +10,130 @@ permissions:
   contents: read
   packages: write
 
+env:
+  IMAGE_NAME: ghcr.io/${{ github.repository }}
+  CHART_NAME: app-blacklist
+  CHART_DIR: helm/app-blacklist
+  CHART_REGISTRY: oci://ghcr.io/noona-hq/charts
+
 jobs:
-  publish:
-    name: Publish
-    if: github.event_name == 'push' && (github.ref_name == 'dev' || github.ref_name == 'main')
-    uses: noona-hq/noona-workflows/.github/workflows/docker-helm-service.yml@main
-    with:
-      mode: ${{ github.ref_name == 'main' && 'PROD' || '' }}
-      image-name: ghcr.io/${{ github.repository }}
-      chart-name: app-blacklist
-    secrets:
-      github-token: ${{ secrets.GITHUB_TOKEN }}
-      noona-deployment-token: ${{ secrets.NOONA_DEPLOYMENT_GITHUB_TOKEN }}
+  docker-image:
+    name: Docker Image
+    runs-on: ubuntu-latest
+    outputs:
+      image-version: ${{ steps.versions.outputs.image-version }}
+      chart-version: ${{ steps.versions.outputs.chart-version }}
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Resolve versions
+        id: versions
+        shell: bash
+        run: |
+          set -euo pipefail
+
+          if [[ "${GITHUB_REF_NAME}" == "main" ]]; then
+            suffix=""
+          else
+            suffix="-dev"
+          fi
+
+          sha=$(git rev-parse --short HEAD)
+
+          {
+            echo "image-version=${sha}${suffix}"
+            echo "chart-version=1.0.0-v${sha}${suffix}"
+            echo "latest-suffix=${suffix}"
+          } >> "${GITHUB_OUTPUT}"
+
+      - name: Log in to GHCR
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Build Docker image
+        run: |
+          docker build --file Dockerfile -t "${IMAGE_NAME}:${{ steps.versions.outputs.image-version }}" .
+
+      - name: Push Docker image
+        run: |
+          docker tag "${IMAGE_NAME}:${{ steps.versions.outputs.image-version }}" "${IMAGE_NAME}:latest${{ steps.versions.outputs.latest-suffix }}"
+          docker push "${IMAGE_NAME}:${{ steps.versions.outputs.image-version }}"
+          docker push "${IMAGE_NAME}:latest${{ steps.versions.outputs.latest-suffix }}"
+
+  helm-chart:
+    name: Helm Chart
+    needs: docker-image
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Set up Helm
+        uses: azure/setup-helm@v4
+
+      - name: Log in to GHCR Helm registry
+        env:
+          GHCR_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GHCR_USERNAME: ${{ github.actor }}
+        run: echo "${GHCR_TOKEN}" | helm registry login ghcr.io -u "${GHCR_USERNAME}" --password-stdin
+
+      - name: Build and push Helm chart
+        env:
+          IMAGE_VERSION: ${{ needs.docker-image.outputs.image-version }}
+          CHART_VERSION: ${{ needs.docker-image.outputs.chart-version }}
+        run: |
+          set -euo pipefail
+
+          perl -0pi -e "s/^version: .*$/version: ${CHART_VERSION}/m" "${CHART_DIR}/Chart.yaml"
+          perl -0pi -e "s#^    repository: .*\$#    repository: ${IMAGE_NAME}#m" "${CHART_DIR}/values.yaml"
+          perl -0pi -e "s/^    tag: .*$/    tag: ${IMAGE_VERSION}/m" "${CHART_DIR}/values.yaml"
+
+          grep -q "^version: ${CHART_VERSION}\$" "${CHART_DIR}/Chart.yaml"
+          grep -q "^    repository: ${IMAGE_NAME}\$" "${CHART_DIR}/values.yaml"
+          grep -q "^    tag: ${IMAGE_VERSION}\$" "${CHART_DIR}/values.yaml"
+
+          mkdir -p .helm-packages
+          helm package "${CHART_DIR}" --destination .helm-packages >/dev/null
+          helm push ".helm-packages/${CHART_NAME}-${CHART_VERSION}.tgz" "${CHART_REGISTRY}"
+
+      - name: Sync noona-deployment
+        env:
+          NOONA_DEPLOYMENT_GITHUB_TOKEN: ${{ secrets.NOONA_DEPLOYMENT_GITHUB_TOKEN }}
+          CHART_VERSION: ${{ needs.docker-image.outputs.chart-version }}
+        run: |
+          set -euo pipefail
+
+          if [[ "${GITHUB_REF_NAME}" == "main" ]]; then
+            branch="main"
+          else
+            branch="dev"
+          fi
+
+          response=$(curl -s -o /dev/null -w "%{http_code}" --location --request POST "https://api.github.com/repos/noona-hq/noona-deployment/actions/workflows/sync-chart.yml/dispatches" \
+            --header "Accept: application/vnd.github+json" \
+            --header "Authorization: Bearer ${NOONA_DEPLOYMENT_GITHUB_TOKEN}" \
+            --header "X-GitHub-Api-Version: 2022-11-28" \
+            --data @- <<EOF
+          {
+            "ref": "${branch}",
+            "inputs": {
+              "branch": "${branch}",
+              "chartName": "${CHART_NAME}",
+              "chartVersion": "${CHART_VERSION}",
+              "chartRepository": "${CHART_REGISTRY}"
+            }
+          }
+          EOF
+          )
+
+          if [[ "${response}" != 204 ]]; then
+            echo "Did not get status code 204 from GitHub workflow dispatch"
+            echo "Got ${response}"
+            exit 1
+          fi


### PR DESCRIPTION
## Summary
- Inline the Docker image, Helm chart, and noona-deployment sync steps in this public repo.
- Remove the dependency on the private `noona-workflows` reusable workflow, which GitHub cannot resolve from a public repo.

## Risk areas
- Publish behavior should match the shared workflow: `main` publishes without `-dev`, other configured branches publish with `-dev`.

## Test plan
- [x] Validate workflow YAML parses locally.
- [x] `git diff --check`
- [ ] Merge to `main` and verify the push workflow creates jobs.
